### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/aadtemplates/f0822deb-6d16-4762-9271-cc01db705f34/015084e5-b854-4a52-b3a7-0369b9b315df/_apis/work/boardbadge/444f4dfd-808a-47b6-a9e0-6ff453edb724)](https://dev.azure.com/aadtemplates/f0822deb-6d16-4762-9271-cc01db705f34/_boards/board/t/015084e5-b854-4a52-b3a7-0369b9b315df/Microsoft.RequirementCategory)
 # azuread-quickstart-templates
 Azure AD Quickstart Templates


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/aadtemplates/f0822deb-6d16-4762-9271-cc01db705f34/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.